### PR TITLE
fix npe for MonitorConfigurationProperty of current user

### DIFF
--- a/src/main/java/io/jenkins/plugins/monitoring/MonitorConfigurationProperty.java
+++ b/src/main/java/io/jenkins/plugins/monitoring/MonitorConfigurationProperty.java
@@ -103,7 +103,7 @@ public class MonitorConfigurationProperty extends UserProperty implements Saveab
      */
     public static Optional<MonitorConfigurationProperty> forCurrentUser() {
         final User current = User.current();
-        return current == null ? Optional.empty() : Optional.of(current.getProperty(MonitorConfigurationProperty.class));
+        return current == null ? Optional.empty() : Optional.ofNullable(current.getProperty(MonitorConfigurationProperty.class));
     }
 
     @Override


### PR DESCRIPTION
Fixes #107. Use `Optional.ofNullable` instead of `Optional.of` to avoid null pointer exception if the `MonitorConfigurationProperty` is null for current user.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
