### PR TITLE
fix uri syntax exception

### DIFF
--- a/src/main/java/io/jenkins/plugins/monitoring/MonitoringWorkflowJobAction.java
+++ b/src/main/java/io/jenkins/plugins/monitoring/MonitoringWorkflowJobAction.java
@@ -39,6 +39,6 @@ public class MonitoringWorkflowJobAction implements Action {
 
     @Override
     public String getUrlName() {
-        return workflowJob.getLastBuild().getNumber() + File.separator + MonitoringMultibranchProjectAction.getURI();
+        return workflowJob.getLastBuild().getNumber() + "/" + MonitoringMultibranchProjectAction.getURI();
     }
 }


### PR DESCRIPTION
Fixes #106. Use `'/'` for URI instead of `File.seperator`.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

