### PR TITLE
Bump jenkins version from 2.249.1 to 2.263.4 LTS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,8 @@
     <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
 
     <properties>
+        <jenkins.baseline>2.263</jenkins.baseline>
+        <jenkins.version>${jenkins.baseline}.4</jenkins.version>
         <revision>1.7.1</revision>
         <changelist>-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>


### PR DESCRIPTION
As long as the update isn't releases for the parent pom (analysis-pom) I manual bump Jenkins version to the actual minimum recommended version 2.263 as described in Choosing a Jenkins version to build against.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

