### PR TITLE
fix broken reference build link

### DIFF
--- a/src/main/resources/io/jenkins/plugins/monitoring/MonitoringDefaultAction/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/monitoring/MonitoringDefaultAction/index.jelly
@@ -22,6 +22,7 @@
             <st:adjunct includes="io.jenkins.plugins.bootstrap5"/>
 
             <h1>${it.getObjectMetadataAction().get().getObjectDisplayName()}</h1>
+            <h6><j:out value="${it.getPullRequestReferenceBuildDescription()}"/></h6>
 
             <metadata:metadata it="${it}"/>
 

--- a/src/main/resources/metadata/metadata.jelly
+++ b/src/main/resources/metadata/metadata.jelly
@@ -22,7 +22,7 @@
                         data-bs-target="#pr-metadata-body" aria-expanded="false"
                         aria-controls="pr-metadata-body">
 
-                    <j:out value="${it.getPullRequestMetadataTitle()}"/>
+                        <j:out value="${it.getPullRequestMetadataTitle()}"/>
 
                 </button>
 


### PR DESCRIPTION
Fix broken reference link in metadata header. Display link now as part of heading.

![Bildschirmfoto 2021-07-21 um 12 05 30](https://user-images.githubusercontent.com/26878018/126471805-c2fca81a-1a50-4889-adc6-ee88590e6d53.png)
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
