### PR TITLE
Migrate from Commons Lang 2 to Commons Lang 3

### DIFF
--- a/src/main/java/io/jenkins/plugins/monitoring/Monitor.java
+++ b/src/main/java/io/jenkins/plugins/monitoring/Monitor.java
@@ -9,7 +9,7 @@ import hudson.model.TaskListener;
 import io.jenkins.plugins.monitoring.util.PortletUtils;
 import io.jenkins.plugins.monitoring.util.PullRequestUtils;
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.plugins.workflow.steps.*;
 import org.json.JSONArray;
 import org.json.JSONObject;


### PR DESCRIPTION
This repository was previously using an inconsistent mix of versions.

Part of the effort to remove Commons Lang 2 from Jenkins core — jenkinsci/jenkins#16404,
jenkinsci/jenkins#26105. Commons Lang 2 is EOL and carries an unfixed advisory
(GHSA-j288-q9x7-2f5v).

The plugin already depends on `commons-lang3-api` (and `commons-text-api`); two files were still
importing the Commons Lang 2 package. This switches them over.

### Testing done

`mvn -B -ntp clean verify` passes locally on Java 21 / macOS.
The `ban-commons-lang-2` enforcer rule was left disabled because it needs parent POM
`6.2116.v7501b_67dc517` or newer; bumping the parent from `4.87` was out of scope here.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

---

🤖 This pull request was generated with AI assistance (Claude Code) as part of a bulk migration
across Jenkins plugins. If anything here looks wrong, please comment on this PR or contact
@parameter.
